### PR TITLE
Disable viewport and handheld friendly meta attributes

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -21,8 +21,10 @@
     <meta name="description" content="{{meta_description}}" />
 
     {{!-- Mobile Meta --}}
-    <meta name="HandheldFriendly" content="True" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- These are commented out because in its current state, this site isn't responsive and
+      the presence of these tags causes sites to be unusable. -->
+    <!-- <meta name="HandheldFriendly" content="True" /> -->
+    <!-- <meta name="viewport" content="width=device-width, initial-scale=1.0" /> -->
 
     {{!-- Brand icon --}}
     <link rel="shortcut icon" href="{{asset "favicon.ico"}}">


### PR DESCRIPTION
The theme in its current state isn't responsive friendly, and shouldn't advertise itself as such. In
order to prevent it from doing so, I'm commenting out a few tags from the HTML header.

I'm planning to go through and make the template responsive so we can add these back in the future, but this is needed to get to a point where folks install this template and their sites become totally unusable on mobile devices.